### PR TITLE
Change top level query which breaks clients

### DIFF
--- a/subgraphs/trips/schema.graphql
+++ b/subgraphs/trips/schema.graphql
@@ -2,7 +2,7 @@ extend schema
   @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key"])
 
 type Query {
-  currentTrip(userId: ID!): Trip
+  currentTrips(userId: ID!): Trip
 }
 
 type Trip @key(fields: "id") {


### PR DESCRIPTION
Example of failing GraphOS operation checks